### PR TITLE
Use cgroups aware processor count by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     parallel (1.25.1)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -19,7 +20,7 @@ GEM
       zeitwerk (~> 2.3)
     ast (2.4.2)
     bump (0.10.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.3.3)
     diff-lcs (1.5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)

--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -337,10 +337,11 @@ module Parallel
       end
     end
 
-    # Number of processors seen by the OS, used for process scheduling
+    # Number of processors seen by the OS or value considering CPU quota if the process is inside a cgroup,
+    # used for process scheduling
     def processor_count
-      require 'etc'
-      @processor_count ||= Integer(ENV['PARALLEL_PROCESSOR_COUNT'] || Etc.nprocessors)
+      require 'concurrent-ruby'
+      @processor_count ||= Integer(ENV['PARALLEL_PROCESSOR_COUNT'] || Concurrent.available_processor_count.to_i)
     end
 
     def worker_number

--- a/parallel.gemspec
+++ b/parallel.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new name, Parallel::VERSION do |s|
   }
   s.files = `git ls-files lib MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"
+  s.add_runtime_dependency "concurrent-ruby", "~> 1.0", ">= 1.3.1"
   s.required_ruby_version = '>= 2.7'
 end

--- a/spec/parallel_spec.rb
+++ b/spec/parallel_spec.rb
@@ -49,11 +49,6 @@ describe Parallel do
         (1..999).should include(Parallel.processor_count)
       end
     end
-
-    it 'uses Etc.nprocessors in Ruby 2.2+' do
-      defined?(Etc).should == "constant"
-      Etc.respond_to?(:nprocessors).should == true
-    end
   end
 
   describe ".physical_processor_count" do


### PR DESCRIPTION
In containerized environments, a number of CPU cores isn't the same as the available CPUs. In this case, we need to consider cgroups.

`concurrent-ruby` now has the method to get that since v1.3.1. I think it's better to use this for setting more container environment friendly default value.

Ref: https://github.com/ruby-concurrency/concurrent-ruby/pull/1038